### PR TITLE
fix: add overlay to convert boolean query params to boolean type

### DIFF
--- a/.speakeasy/overlays/boolean-query-params.overlay.yaml
+++ b/.speakeasy/overlays/boolean-query-params.overlay.yaml
@@ -1,0 +1,10 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Convert boolean query params from string to boolean
+  version: 0.0.0
+actions:
+  - target: $..parameters[?@.schema["x-openrouter-type"] == "boolean"].schema
+    description: Convert x-openrouter-type boolean params from string to boolean
+    update:
+      type: boolean

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -9,6 +9,7 @@ sources:
             - location: .speakeasy/overlays/remove-rss-responses.overlay.yaml
             - location: .speakeasy/overlays/add-headers.overlay.yaml
             - location: .speakeasy/overlays/allof-simplify.overlay.yaml
+            - location: .speakeasy/overlays/boolean-query-params.overlay.yaml
         output: .speakeasy/out.openapi.yaml
         registry:
             location: registry.speakeasyapi.dev/openrouter/sdk/open-router-chat-completions-api


### PR DESCRIPTION
## Summary
- Adds `boolean-query-params.overlay.yaml` that targets params with `x-openrouter-type: boolean` and converts their schema from `type: string` to `type: boolean`
- Registers the overlay in `workflow.yaml`
- Generic overlay — any future param annotated with `x-openrouter-type: boolean` will be automatically converted

## Test plan
- [ ] `speakeasy run` applies the overlay and `out.openapi.yaml` shows `include_disabled` as `type: boolean`
- [ ] Companion PR: OpenRouterTeam/openrouter-web (adds the `x-openrouter-type` extension to the spec)