### PR TITLE
chore: set forwardCompatibleUnionsByDefault to tagged-only

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -59,6 +59,7 @@ python:
   flattenGlobalSecurity: true
   flattenRequests: true
   flatteningOrder: parameters-first
+  forwardCompatibleUnionsByDefault: "tagged-only"
   imports:
     option: openapi
     paths:


### PR DESCRIPTION
## Summary

- Sets the Speakeasy generation config option `forwardCompatibleUnionsByDefault` to `"tagged-only"` in `.speakeasy/gen.yaml`
- This configures the SDK code generator to produce forward-compatible union types for tagged (discriminated) unions, allowing the SDK to gracefully handle new union variants added in future API updates without breaking existing client code