### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -7708,6 +7708,7 @@ components:
                 - Crusoe
                 - DeepInfra
                 - DeepSeek
+                - DekaLLM
                 - Featherless
                 - Fireworks
                 - Friendli
@@ -10089,6 +10090,7 @@ components:
         - Crusoe
         - DeepInfra
         - DeepSeek
+        - DekaLLM
         - Featherless
         - Fireworks
         - Friendli
@@ -10400,6 +10402,7 @@ components:
             - Crusoe
             - DeepInfra
             - DeepSeek
+            - DekaLLM
             - Featherless
             - Fireworks
             - Friendli
@@ -12346,6 +12349,10 @@ components:
                     nullable: true
                   type: object
                 deepseek:
+                  additionalProperties:
+                    nullable: true
+                  type: object
+                dekallm:
                   additionalProperties:
                     nullable: true
                   type: object


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow. If CI passes, it will be auto-merged.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/24346937221)