### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -9761,6 +9761,7 @@ components:
         - audio
         - video
         - rerank
+        - tts
       example: text
       type: string
     OutputModalityEnum:
@@ -14723,6 +14724,7 @@ paths:
                           - completions
                           - embeddings
                           - rerank
+                          - tts
                           - video
                           - null
                         nullable: true


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow. If CI passes, it will be auto-merged.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/24611787884)