### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -6058,6 +6058,10 @@ components:
               example: req-1727282430-aBcDeFgHiJkLmNoPqRsT
               nullable: true
               type: string
+            response_cache_source_id:
+              description: If this generation was served from response cache, contains the original generation ID. Null otherwise.
+              nullable: true
+              type: string
             router:
               description: Router used for the request (e.g., openrouter/auto)
               example: openrouter/auto


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow. If CI passes, it will be auto-merged.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/24846317393)