### PR TITLE
chore: bump speakeasy version to 1.763.2

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,7 +3,7 @@ id: c48cf606-fb42-4a45-9c23-8f0555307828
 management:
   docChecksum: 59bf622329ff2d6d2a28acceada10a6d
   docVersion: 1.0.0
-  speakeasyVersion: 1.680.0
+  speakeasyVersion: 1.763.2
   generationVersion: 2.788.4
   releaseVersion: 0.9.1
   configChecksum: 9c8b936b4b1d37d964e844ee1a15cd4b

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.680.0
+speakeasyVersion: 1.763.2
 sources:
     OpenRouter API:
         sourceNamespace: open-router-chat-completions-api
@@ -17,7 +17,7 @@ targets:
         codeSamplesRevisionDigest: sha256:db86aed74d199f265e2e20442ef652dac0911c8a657ccb3e6614d56a26b8b44e
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.680.0
+    speakeasyVersion: 1.763.2
     sources:
         OpenRouter API:
             inputs:


### PR DESCRIPTION
## Summary
- Bumps `speakeasyVersion` in `.speakeasy/gen.lock` and `.speakeasy/workflow.lock` from `1.680.0` to `1.763.2` (latest release).
- Only the version string is updated; other lock-file fields (`generationVersion`, feature versions, source digests) will be refreshed on the next `speakeasy run` / CI regeneration.

## Test plan
- [ ] CI regeneration succeeds with the new pinned version
- [ ] No unexpected SDK changes appear on the next auto-generated PR