### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -3850,6 +3850,7 @@ components:
         - cohere
         - crusoe
         - darkbloom
+        - decart
         - deepinfra
         - deepseek
         - dekallm
@@ -10779,6 +10780,7 @@ components:
                 - Crucible
                 - Crusoe
                 - Darkbloom
+                - Decart
                 - DeepInfra
                 - DeepSeek
                 - DekaLLM
@@ -15929,6 +15931,7 @@ components:
         - Crucible
         - Crusoe
         - Darkbloom
+        - Decart
         - DeepInfra
         - DeepSeek
         - DekaLLM
@@ -16116,6 +16119,10 @@ components:
             nullable: true
           type: object
         darkbloom:
+          additionalProperties:
+            nullable: true
+          type: object
+        decart:
           additionalProperties:
             nullable: true
           type: object
@@ -16721,6 +16728,7 @@ components:
             - Crucible
             - Crusoe
             - Darkbloom
+            - Decart
             - DeepInfra
             - DeepSeek
             - DekaLLM
@@ -21032,6 +21040,7 @@ paths:
               - cohere
               - crusoe
               - darkbloom
+              - decart
               - deepinfra
               - deepseek
               - dekallm


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/27240755150)