### PR TITLE
docs: update outdated model counts in SDK documentation

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,6 +1,6 @@
 # OpenRouter Python SDK
 
-The OpenRouter Python SDK is a type-safe toolkit for building AI applications with access to 300+ language models through a unified API.
+The OpenRouter Python SDK is a type-safe toolkit for building AI applications with access to 400+ language models through a unified API.
 
 ## Why use the OpenRouter SDK?
 

--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -1,6 +1,6 @@
 # OpenRouter SDK (Beta)
 
-The [OpenRouter SDK](https://openrouter.ai/docs/sdks/python) is a Python toolkit designed to help you build AI-powered features and solutions. Giving you easy access to over 300 models across providers in an easy and type-safe way.
+The [OpenRouter SDK](https://openrouter.ai/docs/sdks/python) is a Python toolkit designed to help you build AI-powered features and solutions. Giving you easy access to 400+ models across providers in an easy and type-safe way.
 
 To learn more about how to use the OpenRouter SDK, check out our [API Reference](https://openrouter.ai/docs/sdks/python/reference) and [Documentation](https://openrouter.ai/docs/sdks/python).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenRouter SDK (Beta)
 
-The [OpenRouter SDK](https://openrouter.ai/docs/sdks/python) is a Python toolkit designed to help you build AI-powered features and solutions. Giving you easy access to over 300 models across providers in an easy and type-safe way.
+The [OpenRouter SDK](https://openrouter.ai/docs/sdks/python) is a Python toolkit designed to help you build AI-powered features and solutions. Giving you easy access to 400+ models across providers in an easy and type-safe way.
 
 To learn more about how to use the OpenRouter SDK, check out our [API Reference](https://openrouter.ai/docs/sdks/python/reference) and [Documentation](https://openrouter.ai/docs/sdks/python).
 


### PR DESCRIPTION
## Summary
- Update model count from 300+ to 400+ in `README.md`, `README-PYPI.md`, and `OVERVIEW.md`
- Keeps SDK documentation aligned with the current number of available models on OpenRouter

## Test plan
- [x] Verified all three docs reference 400+ models consistently
- [x] Verified commits have no co-author trailers
- [ ] Spot-check rendered README on GitHub after merge