### PR TITLE
ci: regenerate SDK directly when merged spec changes land

### DIFF
--- a/.github/workflows/sdk_generation_for_spec_change.yaml
+++ b/.github/workflows/sdk_generation_for_spec_change.yaml
@@ -1,0 +1,36 @@
+name: Generate (spec change merged)
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  statuses: write
+  id-token: write
+"on":
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Force generation of SDKs
+        type: boolean
+        default: false
+      set_version:
+        description: optionally set a specific SDK version
+        type: string
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+    paths:
+      - .speakeasy/in.openapi.yaml
+
+jobs:
+  generate:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    with:
+      force: ${{ github.event.inputs.force }}
+      mode: direct
+      set_version: ${{ github.event.inputs.set_version }}
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      pypi_token: ${{ secrets.PYPI_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
## Summary

OpenAPI spec updates land on `main` automatically (the `chore: update OpenAPI spec from monorepo` PRs), but nothing regenerates the SDK when they do. The only generation trigger is the nightly cron in `sdk_generation.yaml`, which runs Speakeasy in `mode: pr` and produces a rolling PR that requires a manual merge — #205 accumulated changes from Apr 24 to Jun 11 before it was merged by hand, and #127/#169 went stale the same way.

This adds the same workflow `typescript-sdk` uses: when a merged PR touches `.speakeasy/in.openapi.yaml`, run the Speakeasy generator in `mode: direct` so the regenerated SDK commits straight to `main`. Publishing is triggered separately via `workflow_dispatch` on the Publish workflow when ready.

## Test plan

- [ ] After merge, wait for the next automated spec update PR to land (or run this workflow via `workflow_dispatch` with `force: true`)
- [ ] Verify a regeneration commit lands on `main`
