### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -8358,6 +8358,16 @@ components:
             When omitted, defaults to the first model in the Quality preset.
           example: ~anthropic/claude-opus-latest
           type: string
+        preset:
+          description: >-
+            A curated OpenRouter fusion preset (slugs follow `<task>-<tier>`, e.g. `general-high`). Expands server-side
+            into the preset's analysis_models panel and judge model, so callers never name individual models. Explicitly
+            provided `analysis_models` / `model` take precedence.
+          enum:
+            - general-high
+            - general-budget
+          example: general-high
+          type: string
         tools:
           description: >-
             Server tools available to panelist and judge inner calls. Each entry uses the same `{ type, parameters? }`


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/27563745773)