### PR TITLE
docs: remove beta labels from Python SDK README

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -1,4 +1,4 @@
-# OpenRouter SDK (Beta)
+# OpenRouter SDK
 
 The [OpenRouter SDK](https://openrouter.ai/docs/sdks/python) is a Python toolkit designed to help you build AI-powered features and solutions. Giving you easy access to 400+ models across providers in an easy and type-safe way.
 
@@ -277,9 +277,3 @@ To run the test suite, you'll need to set up your environment with an OpenRouter
    ```bash
    pytest
    ```
-
-## Maturity
-
-This SDK is in beta, and there may be breaking changes between versions without a major version update. Therefore, we recommend pinning usage
-to a specific package version. This way, you can install the same version each time without breaking changes unless you are intentionally
-looking for the latest version. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenRouter SDK (Beta)
+# OpenRouter SDK
 
 The [OpenRouter SDK](https://openrouter.ai/docs/sdks/python) is a Python toolkit designed to help you build AI-powered features and solutions. Giving you easy access to 400+ models across providers in an easy and type-safe way.
 
@@ -277,9 +277,3 @@ To run the test suite, you'll need to set up your environment with an OpenRouter
    ```bash
    pytest
    ```
-
-## Maturity
-
-This SDK is in beta, and there may be breaking changes between versions without a major version update. Therefore, we recommend pinning usage
-to a specific package version. This way, you can install the same version each time without breaking changes unless you are intentionally
-looking for the latest version. 


### PR DESCRIPTION
## Summary
- Remove `(Beta)` from README and README-PYPI titles
- Remove the Maturity section beta disclaimer

Closes [SDK-464](https://linear.app/openrouter/issue/SDK-464/remove-beta-labels-from-python-and-typescript-sdks) (python-sdk portion)

## Test plan
- [ ] Verify README and README-PYPI no longer mention SDK beta status