### PR TITLE
fix: update auto-merge workflow triggers and bot username

### DIFF
--- a/.github/workflows/auto-merge-speakeasy-pr.yaml
+++ b/.github/workflows/auto-merge-speakeasy-pr.yaml
@@ -18,11 +18,17 @@ concurrency:
 jobs:
   auto-merge:
     if: |
-      github.event.sender.login == 'app/github-actions' &&
-      github.event.pull_request.user.login == 'app/github-actions' &&
+      github.event.sender.login == 'github-actions[bot]' &&
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
       startsWith(github.event.pull_request.head.ref, 'speakeasy-sdk-regen-') &&
       contains(github.event.pull_request.title, '🐝 Update SDK') &&
-      contains(fromJSON('["patch", "minor", "major"]'), github.event.label.name)
+      (
+        (github.event.action == 'labeled' && contains(fromJSON('["patch", "minor", "major"]'), github.event.label.name)) ||
+        (github.event.action == 'opened' && 
+         (contains(github.event.pull_request.labels.*.name, 'patch') || 
+          contains(github.event.pull_request.labels.*.name, 'minor') || 
+          contains(github.event.pull_request.labels.*.name, 'major')))
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Close superseded Speakeasy PRs

--- a/.github/workflows/auto-merge-speakeasy-pr.yaml
+++ b/.github/workflows/auto-merge-speakeasy-pr.yaml
@@ -5,7 +5,7 @@ name: Auto-merge Speakeasy PR
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, opened]
 
 permissions:
   contents: write
@@ -18,8 +18,8 @@ concurrency:
 jobs:
   auto-merge:
     if: |
-      github.event.sender.login == 'github-actions[bot]' &&
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      github.event.sender.login == 'app/github-actions' &&
+      github.event.pull_request.user.login == 'app/github-actions' &&
       startsWith(github.event.pull_request.head.ref, 'speakeasy-sdk-regen-') &&
       contains(github.event.pull_request.title, '🐝 Update SDK') &&
       contains(fromJSON('["patch", "minor", "major"]'), github.event.label.name)


### PR DESCRIPTION
- Add 'opened' trigger to catch PRs when bot immediately applies label
- Fix bot username from github-actions[bot] to app/github-actions
This enables the auto-merge workflow to work with Speakeasy SDK generation PRs.
## Changes
1. **Added 'opened' trigger** (line 8): The bot applies labels during PR creation, which doesn't fire a separate "labeled" event. Adding "opened" ensures the workflow triggers when Speakeasy creates the PR.
2. **Fixed bot username** (lines 21-22): Changed from `github-actions[bot]` to `app/github-actions` to match the actual bot username used by GitHub Actions.
## Testing
Once merged, the next Speakeasy SDK generation will automatically:
- Create a PR
- Apply the 'patch' label  
- Trigger this workflow
- Auto-merge the PR