### PR TITLE
fix: use GitHub App token for auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-speakeasy-pr.yaml
+++ b/.github/workflows/auto-merge-speakeasy-pr.yaml
@@ -31,9 +31,16 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_DOCS_SYNC_APP_ID }}
+          private-key: ${{ secrets.GH_DOCS_SYNC_APP_PRIVATE_KEY }}
+
       - name: Close superseded Speakeasy PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           CURRENT_PR="${{ github.event.pull_request.number }}"
@@ -64,7 +71,7 @@ jobs:
 
       - name: Auto-merge Speakeasy PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           PR_NUM="${{ github.event.pull_request.number }}"

--- a/.github/workflows/auto-merge-speakeasy-pr.yaml
+++ b/.github/workflows/auto-merge-speakeasy-pr.yaml
@@ -33,7 +33,8 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        # actions/create-github-app-token@v3.2.0 (immutable SHA)
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ secrets.GH_DOCS_SYNC_APP_ID }}
           private-key: ${{ secrets.GH_DOCS_SYNC_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Update the auto-merge workflow to use a GitHub App token instead of GITHUB_TOKEN to ensure downstream workflow triggers (sdk_publish.yaml) after merge.

## Changes

- Generate GitHub App token using GH_DOCS_SYNC_APP_ID and GH_DOCS_SYNC_APP_PRIVATE_KEY secrets
- Use the app token instead of GITHUB_TOKEN for both close-superseded and auto-merge steps
- Ensures sdk_publish.yaml workflow is triggered after automatic merge
- Aligns token usage with typescript-sdk and go-sdk implementations

## Rationale

Using GITHUB_TOKEN prevents downstream workflow triggers because GitHub Actions intentionally blocks workflow chains initiated by actions tokens for security. Using a GitHub App token bypasses this limitation while maintaining security through properly scoped app permissions.

## Verification

This pattern is already successfully used in:
- OpenRouterTeam/typescript-sdk/.github/workflows/auto-merge-speakeasy-pr.yaml
- OpenRouterTeam/go-sdk/.github/workflows/auto-merge-speakeasy-pr.yaml