### PR TITLE
fix: Unexpected response received: Status 200 Content-Type video/mp4

### DIFF
--- a/src/openrouter/video_generation.py
+++ b/src/openrouter/video_generation.py
@@ -726,7 +726,7 @@ class VideoGeneration(BaseSDK):
             request_has_path_params=True,
             request_has_query_params=True,
             user_agent_header="user-agent",
-            accept_header_value="application/octet-stream",
+            accept_header_value="application/octet-stream, video/mp4",
             http_headers=http_headers,
             _globals=operations.ListVideosContentGlobals(
                 http_referer=self.sdk_configuration.globals.http_referer,
@@ -768,6 +768,8 @@ class VideoGeneration(BaseSDK):
 
         response_data: Any = None
         if utils.match_response(http_res, "200", "application/octet-stream"):
+            return http_res
+        if utils.match_response(http_res, "200", "video/mp4"):
             return http_res
         if utils.match_response(http_res, "400", "application/json"):
             http_res_text = utils.stream_to_text(http_res)
@@ -878,7 +880,7 @@ class VideoGeneration(BaseSDK):
             request_has_path_params=True,
             request_has_query_params=True,
             user_agent_header="user-agent",
-            accept_header_value="application/octet-stream",
+            accept_header_value="application/octet-stream, video/mp4",
             http_headers=http_headers,
             _globals=operations.ListVideosContentGlobals(
                 http_referer=self.sdk_configuration.globals.http_referer,
@@ -920,6 +922,8 @@ class VideoGeneration(BaseSDK):
 
         response_data: Any = None
         if utils.match_response(http_res, "200", "application/octet-stream"):
+            return http_res
+        if utils.match_response(http_res, "200", "video/mp4"):
             return http_res
         if utils.match_response(http_res, "400", "application/json"):
             http_res_text = await utils.stream_to_text_async(http_res)


### PR DESCRIPTION
Adding support for accepting video/mp4 in addition to application/octet-stream Content-Type when generating videos.

In effect this change fixes the following Error:

```
File "/Users/istratev/.../video.py", line 13, in get_content
    resp = await open_router.video_generation.get_video_content_async(job_id=job_id, index=0)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/istratev/.../.venv/lib/python3.12/site-packages/openrouter/video_generation.py", line 970, in get_video_content_async
    raise errors.OpenRouterDefaultError(
openrouter.errors.openrouterdefaulterror.OpenRouterDefaultError: Unexpected response received: Status 200 Content-Type video/mp4. Body: ...

```