### PR TITLE
feat: add PR validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,37 @@
+name: PR Validation
+
+on:
+  pull_request:
+    paths-ignore:
+      - .speakeasy/in.openapi.yaml
+
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Build SDK
+        run: uv build
+
+      - name: Type check (mypy)
+        run: uv run --group dev mypy src
+
+      - name: Type check (pyright)
+        run: uv run --group dev pyright src
+
+      - name: Lint (pylint)
+        run: uv run --group dev pylint src --rcfile pylintrc


### PR DESCRIPTION
## Why

The Python SDK has **no `pull_request`-triggered checks**, so Speakeasy regen PRs (`speakeasy-sdk-regen-*`) carry an empty status-check rollup. The auto-merge flow (#364) therefore merges them — and publishes to PyPI — with **zero validation**. The TypeScript SDK validates every regen PR via its `pr-validation.yaml`; Python had no equivalent.

Confirmed empirically: Python regen PRs #357/#352/#349/#347 all have `statusCheckRollup` length 0, while the TS regen PR #512 (same `app/github-actions` bot author) carries a `validate / validate` check from `pull_request` — so a `pull_request` workflow does run on bot-authored regen PRs. The gap was purely the missing workflow.

## What

A single-file `PR Validation` workflow that builds the package and runs the SDK's existing quality gates via `uv`:

- `uv build`
- `uv run --group dev mypy src`
- `uv run --group dev pyright src`
- `uv run --group dev pylint src --rcfile pylintrc`

All four pass clean on current generated code (mypy: 660 files OK; pyright: 0 errors; pylint: 10.00/10).

Notes:
- **No API-key secret** — this repo has no test suite yet (no `tests/`, no pytest dep), so nothing here needs one. Keeping it secret-free also lets it run on fork PRs.
- **`paths-ignore: .speakeasy/in.openapi.yaml`** mirrors TS so pure spec-bump PRs (handled by `sdk_generation_for_spec_change.yaml`) don't double-trigger. Regen PRs change generated `src/**`, so they are validated.
- Single file instead of TS's 3-file `pr-validation → validation-checks → composite action` indirection — there's no second caller, so the nesting isn't needed.

## Interaction with #364

Once both land, the auto-merge `wait_for_checks()` step sees the `validate` check, waits for it, and only direct-merges on success — so validation genuinely gates auto-merge. No change to #364 required; no ordering dependency.

## Verification

- YAML parses; `actionlint` clean.
- All four steps run green locally on current `main`.
- The `validate` check should appear and pass on this PR itself (it touches `.github/**`, not the ignored spec path).