### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.787.0
   generationVersion: 2.914.0
-  releaseVersion: 0.11.46
+  releaseVersion: 1.0.0
   configChecksum: a98327d105a9b554ecf6667b75c4cdea
   repoURL: https://github.com/OpenRouterTeam/python-sdk.git
   installationURL: https://github.com/OpenRouterTeam/python-sdk.git

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -36,7 +36,7 @@ generation:
   documentation: mintlify
   preApplyUnionDiscriminators: true
 python:
-  version: 0.11.46
+  version: 1.0.0
   additionalDependencies:
     dev: {}
     main: {}

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -2,6 +2,8 @@
 
 The OpenRouter Python SDK is a type-safe toolkit for building AI applications with access to 400+ language models through a unified API.
 
+The SDK is stable as of v1.0.
+
 ## Why use the OpenRouter SDK?
 
 Integrating AI models into applications involves handling different provider APIs, managing model-specific requirements, and avoiding common implementation mistakes. The OpenRouter SDK standardizes these integrations and protects you from footguns.
@@ -103,7 +105,7 @@ pip install openrouter
 poetry add openrouter
 ```
 
-**Requirements:** Python 3.9 or higher
+**Requirements:** Python 3.10 or higher
 
 Get your API key from [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys).
 

--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -2,6 +2,8 @@
 
 The [OpenRouter SDK](https://openrouter.ai/docs/sdks/python) is a Python toolkit designed to help you build AI-powered features and solutions. Giving you easy access to 400+ models across providers in an easy and type-safe way.
 
+The OpenRouter Python SDK is stable as of v1.0.
+
 To learn more about how to use the OpenRouter SDK, check out our [API Reference](https://openrouter.ai/docs/sdks/python/reference) and [Documentation](https://openrouter.ai/docs/sdks/python).
 
 <!-- No Summary [summary] -->
@@ -77,7 +79,7 @@ Once that is saved to a file, you can run it with `uv run script.py` where
 <!-- Start Requirements [requirements] -->
 ## Requirements
 
-This SDK requires Python 3.9 or higher. For Python version support policy, see the SDK Installation section above.
+This SDK requires Python 3.10 or higher. For Python version support policy, see the SDK Installation section above.
 <!-- End Requirements [requirements] -->
 
 <!-- Start IDE Support [idesupport] -->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The [OpenRouter SDK](https://openrouter.ai/docs/sdks/python) is a Python toolkit designed to help you build AI-powered features and solutions. Giving you easy access to 400+ models across providers in an easy and type-safe way.
 
+The OpenRouter Python SDK is stable as of v1.0.
+
 To learn more about how to use the OpenRouter SDK, check out our [API Reference](https://openrouter.ai/docs/sdks/python/reference) and [Documentation](https://openrouter.ai/docs/sdks/python).
 
 <!-- No Summary [summary] -->
@@ -77,7 +79,7 @@ Once that is saved to a file, you can run it with `uv run script.py` where
 <!-- Start Requirements [requirements] -->
 ## Requirements
 
-This SDK requires Python 3.9 or higher. For Python version support policy, see the SDK Installation section above.
+This SDK requires Python 3.10 or higher. For Python version support policy, see the SDK Installation section above.
 <!-- End Requirements [requirements] -->
 
 <!-- Start IDE Support [idesupport] -->

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -569,3 +569,13 @@ Based on:
 - [python v0.11.46] .
 ### Releases
 - [PyPI v0.11.46] https://pypi.org/project/openrouter/0.11.46 - .
+
+## 2026-07-20 17:00:00
+### Changes
+Based on:
+- OpenAPI Doc
+- Speakeasy CLI 1.787.0 (2.914.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [python v1.0.0] .
+### Releases
+- [PyPI v1.0.0] https://pypi.org/project/openrouter/1.0.0 - .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrouter"
-version = "0.11.46"
+version = "1.0.0"
 description = "Official Python Client SDK for OpenRouter."
 authors = [{ name = "OpenRouter" },]
 readme = "README-PYPI.md"
@@ -51,5 +51,4 @@ ignore_missing_imports = true
 [tool.pyright]
 venvPath = "."
 venv = ".venv"
-
 

--- a/src/openrouter/_version.py
+++ b/src/openrouter/_version.py
@@ -3,10 +3,10 @@
 import importlib.metadata
 
 __title__: str = "openrouter"
-__version__: str = "0.11.46"
+__version__: str = "1.0.0"
 __openapi_doc_version__: str = "1.0.0"
 __gen_version__: str = "2.914.0"
-__user_agent__: str = "speakeasy-sdk/python 0.11.46 2.914.0 1.0.0 openrouter"
+__user_agent__: str = "speakeasy-sdk/python 1.0.0 2.914.0 1.0.0 openrouter"
 
 try:
     if __package__ is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -213,7 +213,7 @@ wheels = [
 
 [[package]]
 name = "openrouter"
-version = "0.11.46"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary
- Bump SDK/package release metadata from 0.11.46 to 1.0.0
- Update Speakeasy release metadata and lockfile
- Add RELEASES.md entry for v1.0.0
- Mark the SDK stable as of v1.0 in README/PyPI/overview docs
- Align documented Python requirement with pyproject: Python 3.10+

## Validation
- uv build
- uv run --group dev mypy src
- uv run --group dev pyright src
- uv run --group dev pylint src --rcfile pylintrc
- uv run python -c "import openrouter; print(openrouter.__version__)"