### PR TITLE
fix(spec): use global apiKey security for GET /models/user

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -25278,10 +25278,6 @@ components:
       description: 'API key as bearer token in Authorization header'
       scheme: 'bearer'
       type: 'http'
-    bearer:
-      description: 'API key as bearer token in Authorization header'
-      scheme: 'bearer'
-      type: 'http'
 externalDocs:
   description: 'OpenRouter Documentation'
   url: 'https://openrouter.ai/docs'
@@ -33526,8 +33522,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalServerResponse'
           description: 'Internal Server Error - Unexpected server error'
-      security:
-        - bearer: []
       summary: 'List models filtered by user provider preferences, privacy settings, and guardrails'
       tags:
         - 'Models'

--- a/.speakeasy/overlays/fix-models-user-security.overlay.yaml
+++ b/.speakeasy/overlays/fix-models-user-security.overlay.yaml
@@ -1,0 +1,21 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Use the global apiKey scheme for GET /models/user
+  version: 0.0.0
+actions:
+  # `bearer` and `apiKey` are byte-identical schemes (http/bearer, same description),
+  # but only `apiKey` is the document-level default. Because listModelsUser named the
+  # other one, global security could not be hoisted and the generator emitted a
+  # required per-operation `security=` argument on models.list_for_user() — the only
+  # method in the SDK that ignores the client-level api_key. Dropping the override
+  # lets the operation inherit `security: [apiKey]` like the other 94 operations.
+  - target: $.paths["/models/user"].get.security
+    description: Drop the per-operation bearer override so /models/user inherits global apiKey security
+    remove: true
+  # With that override gone, `bearer` has zero references left in the document.
+  # Removing it means a future monorepo sync that points an operation at `bearer`
+  # fails generation loudly instead of silently shipping a second required credential.
+  - target: $.components.securitySchemes.bearer
+    description: Remove the now-unreferenced duplicate of the apiKey security scheme
+    remove: true

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -12,6 +12,7 @@ sources:
             - location: .speakeasy/overlays/boolean-query-params.overlay.yaml
             - location: .speakeasy/overlays/fix-nullable-pagination.overlay.yaml
             - location: .speakeasy/overlays/deprecated-beta-responses-alias.overlay.yaml
+            - location: .speakeasy/overlays/fix-models-user-security.overlay.yaml
         output: .speakeasy/out.openapi.yaml
         registry:
             location: registry.speakeasyapi.dev/openrouter/sdk/open-router-chat-completions-api


### PR DESCRIPTION
## Body

Fixes #581.

### Problem

`models.list_for_user()` is the only method in the SDK (1 of 95 operations) that requires
an operation-level `security=` argument, so the client-level `api_key` is ignored for it:

```python
OpenRouter(api_key="sk-or-v1-...").models.list_for_user()
# TypeError: Models.list_for_user() missing 1 required keyword-only argument: 'security'
```

The cause is in the OpenAPI document, not the generator. `components.securitySchemes`
declares two byte-identical schemes — `apiKey` and `bearer`, both `http/bearer` with the
same description. The document default is `apiKey` (8 references), and `listModelsUser`
alone overrides it with `bearer` (1 reference, the only one in the spec). Because the name
differs from the global scheme, global security can't be hoisted and the generator emits a
required per-operation credential.

### Change

A new overlay, applied last in the chain, does the two removes suggested in the issue:

- drops `security: [bearer]` from `$.paths["/models/user"].get`, so the operation inherits
  the document-level `security: [apiKey]` like the other 94 operations
- removes `$.components.securitySchemes.bearer`, which has no references left afterwards

`.speakeasy/out.openapi.yaml` is the output of the overlay chain, so the same two removes
are applied there to keep the checked-in artifact in sync (-6 lines).

```
.speakeasy/overlays/fix-models-user-security.overlay.yaml | new, 21 lines
.speakeasy/workflow.yaml                                  | +1
.speakeasy/out.openapi.yaml                               | -6
```

### Verification

The Speakeasy CLI isn't available in my environment, so I verified the spec directly:

- both overlay targets match in `in.openapi.yaml` — a no-matching overlay would silently do
  nothing, the failure mode the `deprecated-beta-responses-alias` overlay comments warn
  about — and `bearer` parses as an exact duplicate of `apiKey`
- after the change, `out.openapi.yaml` has `securitySchemes == {apiKey}`, no `security` key
  on `listModelsUser`, global `security` still `[{apiKey: []}]`, and zero operations across
  all 72 paths referencing a missing scheme
- `operationId: listModelsUser`, `x-speakeasy-name-override: listForUser`, and the
  pagination extensions on the operation are untouched
- all 8 registered overlays exist and parse

`src/` is intentionally unchanged.

This PR only touches the spec and overlay chain; regenerating needs the Speakeasy CLI.
On the follow-up regen, expect `security` to drop off `Models.list_for_user` /
`list_for_user_async` (`models_.py:1067`, `:1239`), `operations.ListModelsUserSecurity` to
disappear, and the `OPENROUTER_BEARER` snippet to fall out of
`docs/sdks/models/README.mdx`. Worth confirming on the regen PR before closing #581.

### One judgment call

Removing the `bearer` scheme means a future monorepo sync that points an operation at
`bearer` will fail generation loudly rather than silently shipping another
required-credential method. I think loud is the right trade here, but if you'd rather not
risk blocking the auto-merge bot, drop the second overlay action — the `/models/user`
override removal alone fixes the reported symptom.

Note that the real fix belongs in the monorepo spec; this overlay is the local mitigation
until `bearer` is removed upstream.