### PR TITLE
fix(ci): run pytest in PR validation and fix the stale beta.responses assertion

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Lint (pylint)
         run: uv run --group dev pylint src --rcfile pylintrc
+
+      - name: Test (pytest)
+        run: uv run --group dev pytest tests

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -38,7 +38,9 @@ generation:
 python:
   version: 1.1.23
   additionalDependencies:
-    dev: {}
+    dev:
+      pytest: ==9.1.1
+      pytest-asyncio: ==1.4.0
     main: {}
   allowedRedefinedBuiltins:
     - id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dev = [
     "mypy ==1.15.0",
     "pylint ==3.2.3",
     "pyright ==1.1.398",
+    "pytest ==9.1.1",
+    "pytest-asyncio ==1.4.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_responses_namespace.py
+++ b/tests/test_responses_namespace.py
@@ -1,10 +1,24 @@
 from openrouter import OpenRouter
 
 
+def _public_operations(namespace):
+    return {name for name in dir(namespace) if not name.startswith("_")}
+
+
 def test_responses_namespace_is_ga_and_beta_alias_remains_available():
     client = OpenRouter(api_key="test-key")
 
     assert client.responses is not None
     assert client.beta.responses is not None
-    assert type(client.responses) is type(client.beta.responses)
     assert client.beta.analytics is not None
+
+    # The alias is generated as its own class (BetaResponses), so identity no
+    # longer holds — what has to stay true is that it exposes the same surface.
+    operations = _public_operations(client.responses)
+    assert {"send", "send_async"} <= operations
+    assert _public_operations(client.beta.responses) == operations
+
+    # deprecated-beta-responses-alias.overlay.yaml adds the tag description that
+    # becomes this docstring. Its own comments warn that the overlay can silently
+    # match nothing after a monorepo sync and drop the notice, so assert on it.
+    assert "deprecated" in (type(client.beta.responses).__doc__ or "").lower()

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -75,7 +84,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -126,6 +135,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -227,6 +245,8 @@ dev = [
     { name = "mypy" },
     { name = "pylint" },
     { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -242,6 +262,17 @@ dev = [
     { name = "mypy", specifier = "==1.15.0" },
     { name = "pylint", specifier = "==3.2.3" },
     { name = "pyright", specifier = "==1.1.398" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -251,6 +282,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -387,6 +427,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pylint"
 version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -416,6 +465,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/d6/48740f1d029e9fc4194880d1ad03dcf0ba3a8f802e0e166b8f63350b3584/pyright-1.1.398.tar.gz", hash = "sha256:357a13edd9be8082dc73be51190913e475fa41a6efb6ec0d4b7aab3bc11638d8", size = 3892675, upload-time = "2025-03-26T10:06:06.063Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/e0/5283593f61b3c525d6d7e94cfb6b3ded20b3df66e953acaf7bb4f23b3f6e/pyright-1.1.398-py3-none-any.whl", hash = "sha256:0a70bfd007d9ea7de1cf9740e1ad1a40a122592cfe22a3f6791b06162ad08753", size = 5780235, upload-time = "2025-03-26T10:06:03.994Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## Body

Fixes #585.

### Problem

`tests/test_responses_namespace.py` has been failing on `main` since 2026-07-25, and nothing
caught it: `pytest` is not installed by `uv sync --group dev`, and `pr-validation.yaml` runs
`uv build` / `mypy` / `pyright` / `pylint` but never the tests. PR validation is green while the
suite is red.

### Change

```text
.speakeasy/gen.yaml                  | +4 -2   pytest deps at the generator source
pyproject.toml                       | +2      the same deps in the generated output
uv.lock                              | +83     lockfile
.github/workflows/pr-validation.yaml | +3      Test (pytest) step
tests/test_responses_namespace.py    | +16 -2  stale assertion replaced
```

**Dev dependencies go in `gen.yaml`, not only `pyproject.toml`.** `pyproject.toml` is listed
in `.speakeasy/gen.lock`, so it is generator-owned — adding `pytest` there alone would
survive until the next regeneration and then silently disappear. `python.additionalDependencies.dev`
was `{}`; it now carries both packages, and `pyproject.toml` has the matching lines so the
branch works today without waiting on a regen. Pinned exactly (`==9.1.1`, `==1.4.0`) to match
the existing `mypy` / `pylint` / `pyright` pins.

`pytest-asyncio` is included because `pyproject.toml` already declares
`asyncio_default_fixture_loop_scope`, which without the plugin emits
`PytestConfigWarning: Unknown config option` on every run. That warning is now gone.

The CI step is `uv run --group dev pytest tests`, added after the `pylint` step.

### The assertion was stale, not a real defect

`c75a93c` (2026-07-24) added the test when `beta.py` did `self.responses = Responses(...)` —
literally the same class, so `type(client.responses) is type(client.beta.responses)` held.
`1477485` (2026-07-25) changed it to `self.responses = BetaResponses(...)`, a distinct
generated class, and the identity check broke the next day.

The alias itself is healthy, so this replaces the assertion rather than the behavior. It now
checks what the test name claims: both namespaces expose `send` / `send_async`, their public
surfaces are equal, and the alias's docstring still says "deprecated".

That last assertion is deliberate. `deprecated-beta-responses-alias.overlay.yaml`'s own
comments warn that the overlay can silently match nothing after a monorepo sync and drop the
deprecation notice, and nothing was checking for it. I confirmed the check discriminates —
the GA class's docstring is `"OpenAI-compatible Responses API endpoints"`, with no
"deprecated" in it, so a lost notice fails the test rather than passing vacuously.

### Verification

Ran the full PR-validation job locally, plus the new step:

- `uv build` — both sdist and wheel
- `uv run --group dev mypy src` — no issues in 769 source files
- `uv run --group dev pyright src` — 0 errors, 0 warnings, 0 informations
- `uv run --group dev pylint src --rcfile pylintrc` — 10.00/10
- `uv run --group dev pytest tests` — **4 passed**, no warnings

That last command is the one that could not resolve `pytest` before this change.