### PR TITLE
chore(gen): render OAuth/SCIM as initialisms, keeping o_auth as a deprecated alias

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -56,6 +56,10 @@ python:
   customCasings:
     byok:
       initialism: true
+    oauth:
+      initialism: true
+    scim:
+      initialism: true
     stt:
       initialism: true
     tts:

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -26274,6 +26274,7 @@ paths:
       summary: 'Exchange authorization code for API key'
       tags:
         - 'OAuth'
+        - o_auth
     parameters:
       - $ref: "#/components/parameters/AppIdentifier"
       - $ref: "#/components/parameters/AppDisplayName"
@@ -26457,6 +26458,7 @@ paths:
       summary: 'Create authorization code'
       tags:
         - 'OAuth'
+        - o_auth
       x-speakeasy-name-override: 'createAuthCode'
     parameters:
       - $ref: "#/components/parameters/AppIdentifier"
@@ -37848,6 +37850,9 @@ tags:
   - name: beta.responses
     deprecated: true
     description: Deprecated alias for responses endpoints. Use responses instead. Scheduled for removal (sunset date TBD).
+  - name: o_auth
+    deprecated: true
+    description: Deprecated alias for oauth endpoints. Use oauth instead. Scheduled for removal (sunset date TBD).
 x-retry-strategy:
   initialDelay: 500
   maxAttempts: 3

--- a/.speakeasy/overlays/deprecated-o-auth-alias.overlay.yaml
+++ b/.speakeasy/overlays/deprecated-o-auth-alias.overlay.yaml
@@ -1,0 +1,32 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Keep o_auth as a deprecated SDK alias for oauth
+  version: 0.0.0
+actions:
+  # Registering `oauth` as an initialism in gen.yaml renames the namespace from
+  # client.o_auth to client.oauth. That attribute has been the only public name
+  # for these operations since v1.0, so the old one stays as a deprecated alias
+  # rather than breaking callers on a regen — same treatment beta.responses got.
+  #
+  # `update` appends to the existing tags list, so only the alias is listed here;
+  # re-listing `OAuth` would duplicate the canonical tag.
+  - target: $.paths["/auth/keys"].post
+    description: Add o_auth as a second (deprecated) SDK namespace for the token exchange operation
+    update:
+      tags:
+        - o_auth
+  - target: $.paths["/auth/keys/code"].post
+    description: Add o_auth as a second (deprecated) SDK namespace for the auth code operation
+    update:
+      tags:
+        - o_auth
+  # Defined here rather than edited into the input spec: the monorepo sdk-bot
+  # overwrites in.openapi.yaml and carries no o_auth tag, so a filter-based edit
+  # would silently match nothing and drop the deprecation notice.
+  - target: $.tags
+    description: Define the deprecated o_auth tag
+    update:
+      - name: o_auth
+        deprecated: true
+        description: Deprecated alias for oauth endpoints. Use oauth instead. Scheduled for removal (sunset date TBD).

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -12,6 +12,7 @@ sources:
             - location: .speakeasy/overlays/boolean-query-params.overlay.yaml
             - location: .speakeasy/overlays/fix-nullable-pagination.overlay.yaml
             - location: .speakeasy/overlays/deprecated-beta-responses-alias.overlay.yaml
+            - location: .speakeasy/overlays/deprecated-o-auth-alias.overlay.yaml
         output: .speakeasy/out.openapi.yaml
         registry:
             location: registry.speakeasyapi.dev/openrouter/sdk/open-router-chat-completions-api


### PR DESCRIPTION
## Body

Fixes #587.

### Problem

PR #561 normalized `BYOK` / `STT` / `TTS` via `customCasings` and left two initialisms behind.
The user-facing one is OAuth: the tag `OAuth` is mixed-case, so the `snake_case` attribute splits
on the internal capital and the namespace is `client.o_auth`, not `client.oauth` — while the
generated docs directory is `docs/sdks/oauth/`. `Scim` is the other: its class name never got
the initialism treatment that `BYOK`, `STT`, `TTS`, and `APIKeys` have.

### Change

```text
.speakeasy/gen.yaml                                      | +4   oauth + scim initialisms
.speakeasy/overlays/deprecated-o-auth-alias.overlay.yaml | new  o_auth kept as a deprecated alias
.speakeasy/workflow.yaml                                 | +1   overlay registered
.speakeasy/out.openapi.yaml                              | +5   overlay output kept in sync
```

Both entries use the same proven `initialism: true` form #561 introduced.

`client.o_auth` has been the only public name for these operations since `v1.0`, so the rename
is paired with a deprecated alias rather than shipped bare — a regen would otherwise break
every caller with no migration path. The overlay adds `o_auth` as a second tag on both OAuth
operations, mirroring `deprecated-beta-responses-alias.overlay.yaml` line for line, including
its note about defining the tag in the overlay so a monorepo sync can't silently drop it.

### The two halves have very different blast radii

Worth knowing before merging, since `initialism: true` renders the token in all-caps
*everywhere* it appears — that is why #561 produced `BYOKKey`, `STTRequest`, `STTInputAudio`:

- **`oauth` touches exactly one symbol.** Grepping `src/` for `OAuth`-containing symbols returns
  a single hit, the `OAuth` class. So this fixes the attribute and renames one class.
- **`scim` touches six.** `Scim`, plus `ScimGroup`, `ScimGroupMapping`, `ScimGroupMappingRole`,
  `ScimGroupMappingTypedDict`, `ScimGroupTypedDict`, and 3 docs pages.

The `scim` attribute is already correct, so unlike OAuth there is no ergonomics win — it is
cosmetic class-name consistency bought with six renamed public component classes. It is
included because #587 asks for it, but it is three lines to drop from `gen.yaml` and the OAuth
half stands alone. Happy to split it out if you'd prefer.

### Verification

The Speakeasy CLI isn't available in my environment, so I verified the config and spec directly:

- `customCasings` is exactly `{byok, oauth, scim, stt, tts}`, all using `initialism: true`
- the new overlay is registered, and all 8 overlays exist and parse
- both overlay targets match in `in.openapi.yaml` (tags `['OAuth']`, no pre-existing `o_auth`
  tag), so the overlay cannot silently no-op
- in `out.openapi.yaml` both operations now carry `['OAuth', 'o_auth']`, the alias tag is
  present and `deprecated: true` with the sunset notice, the canonical `OAuth` tag is
  unchanged, and no other operation picked up the alias

### `src/` is intentionally unchanged

The rename only materializes on regeneration. Two things to confirm on the regen PR, since I
could not:

1. the attribute lands as `client.oauth`, with `client.o_auth` still present and marked deprecated
2. what the class renders as — the `BYOK` / `STT` precedent points to `OAUTH`, which is
   consistent with the other initialisms but is not the canonical spelling of `OAuth`. If you want
   `OAuth` preserved on the class while the attribute becomes `oauth`, that needs a different
   `customCasings` knob than the one #561 established, and I could not find its schema in the
   public docs.