### PR TITLE
fix(docs): make the README Resource Management snippet valid Python

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -306,6 +306,7 @@ def main():
         api_key=os.getenv("OPENROUTER_API_KEY", ""),
     ) as open_router:
         # Rest of application here...
+        pass
 
 
 # Or when using async:
@@ -318,6 +319,7 @@ async def amain():
         api_key=os.getenv("OPENROUTER_API_KEY", ""),
     ) as open_router:
         # Rest of application here...
+        pass
 ```
 <!-- End Resource Management [resource-management] -->
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ def main():
         api_key=os.getenv("OPENROUTER_API_KEY", ""),
     ) as open_router:
         # Rest of application here...
+        pass
 
 
 # Or when using async:
@@ -318,6 +319,7 @@ async def amain():
         api_key=os.getenv("OPENROUTER_API_KEY", ""),
     ) as open_router:
         # Rest of application here...
+        pass
 ```
 <!-- End Resource Management [resource-management] -->
 

--- a/tests/test_docs_snippets.py
+++ b/tests/test_docs_snippets.py
@@ -1,0 +1,44 @@
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SNIPPET = re.compile(r"```python\n(.*?)```", re.S)
+
+
+def _snippets():
+    """Every documented snippet that actually uses the SDK.
+
+    Blocks under docs/components/ and docs/operations/ are type signatures rather
+    than programs, so only blocks that import from `openrouter` are collected.
+    """
+    files = [ROOT / "README.md", ROOT / "README-PYPI.md", ROOT / "USAGE.md"]
+    files += sorted(ROOT.glob("docs/**/*.mdx"))
+
+    found = []
+    for path in files:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in SNIPPET.finditer(text):
+            code = match.group(1)
+            if "from openrouter" in code or "import openrouter" in code:
+                line = text[: match.start()].count("\n") + 1
+                found.append(
+                    pytest.param(code, id=f"{path.relative_to(ROOT).as_posix()}:{line}")
+                )
+    return found
+
+
+@pytest.mark.parametrize("code", _snippets())
+def test_documented_snippet_is_valid_python(code):
+    # The README's Resource Management block is generated between Speakeasy
+    # section markers, so a regeneration can silently reintroduce the empty
+    # `with` bodies this guards against.
+    ast.parse(code)
+
+
+def test_snippet_collection_is_not_empty():
+    assert len(_snippets()) > 100


### PR DESCRIPTION
Fixes #589.

### Problem

The `Resource Management` sample in `README.md` and `README-PYPI.md` cannot be run as printed.
Both `with` blocks contain only a comment, so the snippet is a syntax error:

```text
IndentationError: expected an indented block after 'with' statement on line 5 (line 15)
```

`README-PYPI.md` is the `readme` in `pyproject.toml`, so this is also the project description
rendered on PyPI.

### Change

```text
README.md                   | +2   pass in both with-bodies
README-PYPI.md              | +2   same
tests/test_docs_snippets.py | new, 43 lines
```

The fix itself is four lines. The test is the part that matters: the block sits between
Speakeasy's section markers,

```html
<!-- Start Resource Management [resource-management] -->
...
<!-- End Resource Management [resource-management] -->
```

which is how the generator locates and replaces that section — so a regeneration can silently
put the empty `with` bodies back. `tests/test_docs_snippets.py` parametrizes every documented
snippet that imports from `openrouter` — **731 blocks** across `README.md`, `README-PYPI.md`,
`USAGE.md`, and all of `docs/**/*.mdx` — and asserts each one parses. Test IDs are `path:line`,
so a regression names the exact file and line rather than just reporting that a snippet broke.

Blocks under `docs/components/` and `docs/operations/` are type signatures rather than
programs, so the collector skips anything that does not import from `openrouter`.

(731 is higher than the 119 quoted in #589 — that count covered only `docs/sdks/**`; this sweeps
every `docs/` subtree. All 731 parse.)

### Verification

- the two previously-broken cases now pass by ID: `README.md:297` and `README-PYPI.md:297`
- full suite: **734 passed, 1 failed**. The single failure is
  `test_responses_namespace.py::test_responses_namespace_is_ga_and_beta_alias_remains_available`,
  which is #585 and already red on `main` before this branch. Nothing here touches it.

### Two notes

`README.md` and `README-PYPI.md` were deliberately left out of `.genignore`. Adding them would
freeze the whole file and stop future generated sections from updating — the same trap that
deleted the OAuth PKCE helpers in #583. If a regeneration does clobber this fix, it belongs
upstream in the Speakeasy template, and the new test is what will surface that.

The new test only runs under `uv run --with pytest` until #585 lands `pytest` in the dev group
and adds the CI step. Until then CI will not execute it.