### PR TITLE
chore: clean up .gitignore and remove unused output.zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 *.egg
-# Speakeasy generation artifacts (generated in OSS repo, not here)
-.speakeasy/*.lock
-.speakeasy/*.openapi.yaml
 # Environment
 .env
 .env.local


### PR DESCRIPTION
Addresses #592, items 1 and 2. Item 3 is answered below but deliberately unchanged, so this
does not auto-close the issue.

### Change

```text
output.zip | deleted (0 bytes)
.gitignore | -3   dead .speakeasy patterns + misleading comment
```

**`output.zip`** — unreferenced anywhere in the repo; `grep` across the tree returns nothing, and
its only commit is the Copybara import (`5f2c0ee`).

**`.gitignore`** — checked both directions before removing the two patterns. All four tracked
files match them (`gen.lock`, `workflow.lock`, `in.openapi.yaml`, `out.openapi.yaml`), and
`git status --ignored` confirms the patterns are currently hiding zero untracked files. So
removing them changes no ignore behaviour; it only stops the file from implying those artifacts
aren't committed here. The neighbouring `.speakeasy/temp/`, `.speakeasy/logs/`, and
`.speakeasy/reports` rules cover genuinely untracked output and are untouched.

### Item 3: the `/messages` exclusion — no change, and I'd argue there shouldn't be

Two findings while checking it.

**The exclusion is deliberate and owned upstream.** `x-speakeasy-ignore: true` is present in
`in.openapi.yaml`, not added by any local overlay — it comes from the monorepo spec. That
settles the "worth confirming" question without needing a maintainer.

Given that, both suggested cleanups would be net-negative:

- `x-speakeasy-name-override: 'create'` is not dead weight, it is load-bearing *if* the
  exclusion is ever lifted — it is exactly what makes the namespace `client.messages.create`.
  Stripping it via an overlay would sabotage a future un-ignoring.
- The orphaned `Anthropic Messages` tag produces no artifact: no `docs/sdks/` directory, no
  `docs.json` nav entry, no SDK class. Removing it would mean adding and maintaining a new
  overlay for zero observable change.

**One correction to the issue's premise.** "We ship the types for an endpoint the client can't
call" isn't accurate. All 8 `messages*` component modules are consumed by `presets.py` —
`presets.create_presets_messages` takes `components.MessagesRequest`,
`MessagesMessageParam`, `MessagesRequestToolUnion`, `MessagesFallbackParam`,
`MessagesOutputConfig` and friends. They serve a callable endpoint; they just are not reachable
through a `client.messages` namespace.

What remains in item 3 is the product question — should `/messages` be exposed at all — and
that is a monorepo spec decision rather than something this repo can settle.

### Verification

- `uv build` produces both sdist and wheel
- test suite: **3 passed, 1 failed** — the failure is
  `test_responses_namespace.py::test_responses_namespace_is_ga_and_beta_alias_remains_available`,
  which is #585 and already red on `main` before this branch.